### PR TITLE
feat: update easy-template-x dependency and remove json flatten function

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The tags for lists/containers are the same as default.
 
 ## Developer
 
-Hi, 
+Hi,
 
 My name is Bram and I am the developer of this node.
 I am an independant consultant and expert partner of n8n.
@@ -36,7 +36,7 @@ For questions or issues with nodes, please open an issue on Github.
 
 ## Sponsor
 
-This node was developed for a client and they allowed me to make it public. 
+This node was developed for a client and they allowed me to make it public.
 
 Developed for [Energy SOAR](https://energysoar.com?ref=kr495s) - Security orchestration, automation and response tool.
 
@@ -61,4 +61,12 @@ Developed on an older version of n8n but since then tested on version 0.222.1
 
 ## Version history
 
-v1.0
+v1.0.0
+
+- Update `easy-template-x` dependency to latest version.
+- Don't flatten JSON before providing it to the template handler.<br>
+	This should provide support for `easy-template-x` plugins like the [link plugin](https://github.com/alonrbar/easy-template-x#link-plugin).
+
+v0.1.0
+
+Initial setup

--- a/nodes/GenerateReport/GenerateReport.node.ts
+++ b/nodes/GenerateReport/GenerateReport.node.ts
@@ -1,6 +1,5 @@
 import { IExecuteFunctions } from 'n8n-core';
 import {
-	IDataObject,
 	INodeExecutionData,
 	INodePropertyOptions,
 	INodeType,
@@ -97,23 +96,6 @@ export class GenerateReport implements INodeType {
 	};
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
-
-		const flattenJSON = (obj = {} as IDataObject, res = {} as IDataObject, extraKey = '' as string) => {
-			for(var key in obj){
-			   if(typeof obj[key] !== 'object'){
-				  res[extraKey + key] = obj[key];
-			   }else{
-				  if(Array.isArray(obj[key])){
-					 res[extraKey + key] = obj[key];
-				  }
-				  else{
-					 flattenJSON(obj[key] as IDataObject, res, `${extraKey}${key}.`);
-				  }
-			   };
-			};
-			return res;
-		 };
-
 		const items = this.getInputData();
 
 		const returnData: INodeExecutionData[] = [];
@@ -133,9 +115,9 @@ export class GenerateReport implements INodeType {
 			const data = this.getNodeParameter('data', itemIndex) as string;
 			const outputFileName = this.getNodeParameter('outputFileName', itemIndex) as string;
 			const convertToPDF = this.getNodeParameter('convertToPDF', itemIndex,false) as boolean;
-			let templateData;
+			let templateData: TemplateData;
 			try{
-				templateData = flattenJSON(JSON.parse(data)) as TemplateData;
+				templateData = JSON.parse(data);
 			}
 			catch(err){
 				throw new NodeOperationError(this.getNode(), 'Something went wrong while parsing the template data.' + err as string);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "easy-template-x": "^3.1.0",
+        "easy-template-x": "^6.2.1",
         "iconv-lite": "^0.6.3",
         "libreoffice-convert": "^1.4.1"
       },
@@ -508,9 +508,10 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.7.tgz",
-      "integrity": "sha512-sI1Ly2cODlWStkINzqGrZ8K6n+MTSbAeQnAipGyL+KZCXuHaRlj2gyyy8B/9MvsFFqN7XHryQnB2QwhzvJXovg==",
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -1799,11 +1800,13 @@
       }
     },
     "node_modules/easy-template-x": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/easy-template-x/-/easy-template-x-3.1.0.tgz",
-      "integrity": "sha512-n/tjM5AESPy/a56e8LgpGf6FWusw42QXDNaBcnGmj5G9euzi+l0yTTwgFFD7twp4SfplDMmC5626Va4CrfKOow==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/easy-template-x/-/easy-template-x-6.2.1.tgz",
+      "integrity": "sha512-RBYhIlxl0z0Cd1vTYVh3AvMiFqYvSl1zAUnXk/Le0OHNTXgoyjiZlyFcyVmCj5SuWtElopj5AYbhW1B64SDpFw==",
+      "license": "MIT",
       "dependencies": {
-        "@xmldom/xmldom": "0.8.7",
+        "@xmldom/xmldom": "0.8.10",
+        "json5": "2.2.3",
         "jszip": "3.10.1",
         "lodash.get": "4.4.2"
       }
@@ -3616,6 +3619,18 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/jsprim": {
       "version": "1.4.2",
@@ -7601,9 +7616,9 @@
       }
     },
     "@xmldom/xmldom": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.7.tgz",
-      "integrity": "sha512-sI1Ly2cODlWStkINzqGrZ8K6n+MTSbAeQnAipGyL+KZCXuHaRlj2gyyy8B/9MvsFFqN7XHryQnB2QwhzvJXovg=="
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw=="
     },
     "acorn": {
       "version": "8.8.2",
@@ -7615,7 +7630,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv": {
       "version": "6.12.6",
@@ -8630,11 +8646,12 @@
       }
     },
     "easy-template-x": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/easy-template-x/-/easy-template-x-3.1.0.tgz",
-      "integrity": "sha512-n/tjM5AESPy/a56e8LgpGf6FWusw42QXDNaBcnGmj5G9euzi+l0yTTwgFFD7twp4SfplDMmC5626Va4CrfKOow==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/easy-template-x/-/easy-template-x-6.2.1.tgz",
+      "integrity": "sha512-RBYhIlxl0z0Cd1vTYVh3AvMiFqYvSl1zAUnXk/Le0OHNTXgoyjiZlyFcyVmCj5SuWtElopj5AYbhW1B64SDpFw==",
       "requires": {
-        "@xmldom/xmldom": "0.8.7",
+        "@xmldom/xmldom": "0.8.10",
+        "json5": "2.2.3",
         "jszip": "3.10.1",
         "lodash.get": "4.4.2"
       }
@@ -10056,6 +10073,11 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true
     },
+    "json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
+    },
     "jsprim": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
@@ -11132,7 +11154,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/popsicle-content-encoding/-/popsicle-content-encoding-1.0.0.tgz",
       "integrity": "sha512-4Df+vTfM8wCCJVTzPujiI6eOl3SiWQkcZg0AMrOkD1enMXsF3glIkFUZGvour1Sj7jOWCsNSEhBxpbbhclHhzw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "popsicle-cookie-jar": {
       "version": "1.0.0",
@@ -11156,7 +11179,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/popsicle-redirects/-/popsicle-redirects-1.1.1.tgz",
       "integrity": "sha512-mC2HrKjdTAWDalOjGxlXw9j6Qxrz/Yd2ui6bPxpi2IQDYWpF4gUAMxbA8EpSWJhLi0PuWKDwTHHPrUPGutAoIA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "popsicle-transport-http": {
       "version": "1.2.1",
@@ -11171,13 +11195,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/popsicle-transport-xhr/-/popsicle-transport-xhr-2.0.0.tgz",
       "integrity": "sha512-5Sbud4Widngf1dodJE5cjEYXkzEUIl8CzyYRYR57t6vpy9a9KPGQX6KBKdPjmBZlR5A06pOBXuJnVr23l27rtA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "popsicle-user-agent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/popsicle-user-agent/-/popsicle-user-agent-1.0.0.tgz",
       "integrity": "sha512-epKaq3TTfTzXcxBxjpoKYMcTTcAX8Rykus6QZu77XNhJuRHSRxMd+JJrbX/3PFI0opFGSN0BabbAYCbGxbu0mA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "posix-character-classes": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-generate-report",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Fill in DocX Template with Data from JSON object",
   "keywords": [
     "n8n-community-node-package"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "typescript": "~4.8.4"
   },
   "dependencies": {
-    "easy-template-x": "^3.1.0",
+    "easy-template-x": "^6.2.1",
     "iconv-lite": "^0.6.3",
     "libreoffice-convert": "^1.4.1"
   }


### PR DESCRIPTION
This PR updates the easy-template-x dependency (fixes #5) and removes the `flattenJSON` function. 
The reason for removing the function is that some easy-template-x's plugins, like the link plugin, require non-flattened json objects. Also, I couldn't really find a reason why it was used anyways. If it is really needed please let me know, so we can think of a better way to implement the plugin features.